### PR TITLE
Return early if the inverse of determinant is not finite (fixes #4)

### DIFF
--- a/source/D3DXMatrix.cpp
+++ b/source/D3DXMatrix.cpp
@@ -1,5 +1,6 @@
 #include <d3dx9.h>
 #include <DirectXMath.h>
+#include <cmath>
 
 // D3DX Matrix functions implemented in the means of DirectXMath
 
@@ -12,7 +13,7 @@ D3DXMATRIX* WINAPI D3DXMatrixInverse_XM(D3DXMATRIX *pOut, FLOAT *pDeterminant, C
 	const float det = XMVectorGetX(determinant);
 
 	// Mirror the behaviour of D3DXMatrixInverse
-	if (det == 0.0f)
+	if (det == 0.0f || !std::isfinite(1.0f / det))
 	{
 		return nullptr;
 	}


### PR DESCRIPTION
This change better aligns our implementation with behavior found in `d3dx9_31!c_D3DXMatrixInverse`.